### PR TITLE
Allow characters in modifiers by making \addplus a string operation

### DIFF
--- a/template/character-sheet/player-input.tex
+++ b/template/character-sheet/player-input.tex
@@ -1,4 +1,4 @@
-\newcommand{\addplus}[1] {\ifnum#1<0 #1 \else +#1 \fi}
+\newcommand{\addplus}[1]{\IfBeginWith{#1}{-}{#1}{+#1}}
 
 % CHARACTER NAME
 \rput[cc](201.61106163,959.86850934){\LARGE \entryfont \textcolor{text-color}{\CharacterNameValue}}


### PR DESCRIPTION
Hi, I'm using dungeonsheets with your wonderful latex template. I hadn't update your template in some time, and I just found out that dungeonsheets and your repo diverged a bit, especially [the recent patch that automatically adds plus signs to modifiers](https://github.com/matsavage/DND-5e-LaTeX-Character-Sheet-Template/commit/ec7cc922ac342ab5de27cc3c3ede06f190f658db).

[I wrote a dungeonsheets patch already](https://github.com/PJBrs/dungeon-sheets/commit/c7fb1defb34574fdf1c17cea20da5f20a05342a3) (not yet merged) to deal with most changes in this repo, but the \addplus command defined in template/character-sheet/player-input.tex causes build failures because dungeonsheets sometimes includes string characters for advantage and disadvantage in modifiers, for instance: natural explorer feat of revised ranger gives advantage on initiative, resulting in something like +5(A).  The \addplus command checks integer values but it cannot deal with string values.

This patch makes the \addplus command more resilient by treating modifiers as string values instead of integers. On dungeonsheets, this fixes, for instance, the compilation of revised ranger characters