### PR TITLE
feat: adds cat logs on failed build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -137,6 +137,10 @@
                 latexmk -file-line-error -xelatex ${directory}/${file_name}
               '';
 
+              postBuild = ''
+                cat ./*.log
+              '';
+
               installPhase = ''
                 mkdir --parents $out/logs
                 cp ./*.log $out/logs


### PR DESCRIPTION
Adds logging step to `postBuild` in nix flake to log output on a failed build