### PR TITLE
Add a command to specify expended spell slots

### DIFF
--- a/template/character-sheet-commands.tex
+++ b/template/character-sheet-commands.tex
@@ -233,6 +233,27 @@
 \newcommand{\EighthLevelSpellSlotsTotal}[1]{\renewcommand{\EighthLevelSpellSlotsTotalValue}{#1}}
 \newcommand{\NinthLevelSpellSlotsTotal}[1]{\renewcommand{\NinthLevelSpellSlotsTotalValue}{#1}}
 
+% EXPENDED SPELL SLOTS
+\newcommand{\FirstLevelSpellSlotsExpendedValue}{}
+\newcommand{\SecondLevelSpellSlotsExpendedValue}{}
+\newcommand{\ThirdLevelSpellSlotsExpendedValue}{}
+\newcommand{\FourthLevelSpellSlotsExpendedValue}{}
+\newcommand{\FifthLevelSpellSlotsExpendedValue}{}
+\newcommand{\SixthLevelSpellSlotsExpendedValue}{}
+\newcommand{\SeventhLevelSpellSlotsExpendedValue}{}
+\newcommand{\EighthLevelSpellSlotsExpendedValue}{}
+\newcommand{\NinthLevelSpellSlotsExpendedValue}{}
+
+\newcommand{\FirstLevelSpellSlotsExpended}[1]{\renewcommand{\FirstLevelSpellSlotsExpendedValue}{#1}}
+\newcommand{\SecondLevelSpellSlotsExpended}[1]{\renewcommand{\SecondLevelSpellSlotsExpendedValue}{#1}}
+\newcommand{\ThirdLevelSpellSlotsExpended}[1]{\renewcommand{\ThirdLevelSpellSlotsExpendedValue}{#1}}
+\newcommand{\FourthLevelSpellSlotsExpended}[1]{\renewcommand{\FourthLevelSpellSlotsExpendedValue}{#1}}
+\newcommand{\FifthLevelSpellSlotsExpended}[1]{\renewcommand{\FifthLevelSpellSlotsExpendedValue}{#1}}
+\newcommand{\SixthLevelSpellSlotsExpended}[1]{\renewcommand{\SixthLevelSpellSlotsExpendedValue}{#1}}
+\newcommand{\SeventhLevelSpellSlotsExpended}[1]{\renewcommand{\SeventhLevelSpellSlotsExpendedValue}{#1}}
+\newcommand{\EighthLevelSpellSlotsExpended}[1]{\renewcommand{\EighthLevelSpellSlotsExpendedValue}{#1}}
+\newcommand{\NinthLevelSpellSlotsExpended}[1]{\renewcommand{\NinthLevelSpellSlotsExpendedValue}{#1}}
+
 % CANTRIPS
 \newcommand{\CantripSlotAValue}{}
 \newcommand{\CantripSlotBValue}{}

--- a/template/half-spell-sheet/player-input.tex
+++ b/template/half-spell-sheet/player-input.tex
@@ -27,6 +27,9 @@
 % TOTAL SLOTS
 \rput[cc](91.03045507,563.85545107){\LARGE \entryfont \textcolor{primary-indicator-color}{\FirstLevelSpellSlotsTotalValue}}
 
+% EXPENDED SLOTS
+\rput[cc](201.03045507,563.85545107){\LARGE \entryfont \textcolor{primary-indicator-color}{\FirstLevelSpellSlotsExpendedValue}}
+
 % KNOWN SPELLS
 \rput[l](63.17786559,526.122385345){\footnotesize \entryfont \textcolor{text-color}{\FirstLevelSpellSlotAValue}}
 \rput[l](63.17786559,507.455719145){\footnotesize \entryfont \textcolor{text-color}{\FirstLevelSpellSlotBValue}}
@@ -59,6 +62,9 @@
 % TOTAL SLOTS
 \rput[cc](343.03044877,847.49771214){\LARGE \entryfont \textcolor{primary-indicator-color}{\SecondLevelSpellSlotsTotalValue}}
 
+% EXPENDED SLOTS
+\rput[cc](453.03044877,847.49771214){\LARGE \entryfont \textcolor{primary-indicator-color}{\SecondLevelSpellSlotsExpendedValue}}
+
 % KNOWN SPELLS
 \rput[l](315.17785929,812.43171302){\footnotesize \entryfont \textcolor{text-color}{\SecondLevelSpellSlotAValue}}
 \rput[l](315.17785929,793.76504682){\footnotesize \entryfont \textcolor{text-color}{\SecondLevelSpellSlotBValue}}
@@ -83,6 +89,9 @@
 % LEVEL 3
 % TOTAL SLOTS
 \rput[cc](343.03044877,431.71745300){\LARGE \entryfont \textcolor{primary-indicator-color}{\ThirdLevelSpellSlotsTotalValue}}
+
+% EXPENDED SLOTS
+\rput[cc](453.03044877,431.71745300){\LARGE \entryfont \textcolor{primary-indicator-color}{\ThirdLevelSpellSlotsExpendedValue}}
 
 % KNOWN SPELLS
 \rput[l](315.17785929,396.651053875){\footnotesize \entryfont \textcolor{text-color}{\ThirdLevelSpellSlotAValue}}
@@ -109,6 +118,9 @@
 % TOTAL SLOTS
 \rput[cc](592.53044253,847.49771214){\LARGE \entryfont \textcolor{primary-indicator-color}{\FourthLevelSpellSlotsTotalValue}}
 
+% EXPENDED SLOTS
+\rput[cc](702.53044253,847.49771214){\LARGE \entryfont \textcolor{primary-indicator-color}{\FourthLevelSpellSlotsExpendedValue}}
+
 % KNOWN SPELLS
 \rput[l](564.67785305,812.43171302){\footnotesize \entryfont \textcolor{text-color}{\FourthLevelSpellSlotAValue}}
 \rput[l](564.67785305,793.76504682){\footnotesize \entryfont \textcolor{text-color}{\FourthLevelSpellSlotBValue}}
@@ -133,6 +145,9 @@
 % LEVEL 5
 % TOTAL SLOTS
 \rput[cc](592.53044253,431.16145114){\LARGE \entryfont \textcolor{primary-indicator-color}{\FifthLevelSpellSlotsTotalValue}}
+
+% EXPENDED SLOTS
+\rput[cc](702.53044253,431.16145114){\LARGE \entryfont \textcolor{primary-indicator-color}{\FifthLevelSpellSlotsExpendedValue}}
 
 % KNOWN SPELLS
 \rput[l](564.67785305,396.09505201){\footnotesize \entryfont \textcolor{text-color}{\FifthLevelSpellSlotAValue}}

--- a/template/spell-sheet/player-input.tex
+++ b/template/spell-sheet/player-input.tex
@@ -24,6 +24,9 @@
 % TOTAL SLOTS
 \rput[cc](91.03045507,623.85545107){\LARGE \entryfont \textcolor{primary-indicator-color}{\FirstLevelSpellSlotsTotalValue}}
 
+% EXPENDED SLOTS
+\rput[cc](201.03045507,623.85545107){\LARGE \entryfont \textcolor{primary-indicator-color}{\FirstLevelSpellSlotsExpendedValue}}
+
 % KNOWN SPELLS
 \rput[l](63.17786559,586.122385345){\footnotesize \entryfont \textcolor{text-color}{\FirstLevelSpellSlotAValue}}
 \rput[l](63.17786559,567.455719145){\footnotesize \entryfont \textcolor{text-color}{\FirstLevelSpellSlotBValue}}
@@ -42,6 +45,9 @@
 % LEVEL 2
 % TOTAL SLOTS
 \rput[cc](91.03045507,319.09665869){\LARGE \entryfont \textcolor{primary-indicator-color}{\SecondLevelSpellSlotsTotalValue}}
+
+% EXPENDED SLOTS
+\rput[cc](201.03045507,319.09665869){\LARGE \entryfont \textcolor{primary-indicator-color}{\SecondLevelSpellSlotsExpendedValue}}
 
 % KNOWN SPELLS
 \rput[l](63.17786559,284.030259565){\footnotesize \entryfont \textcolor{text-color}{\SecondLevelSpellSlotAValue}}
@@ -62,6 +68,9 @@
 % TOTAL SLOTS
 \rput[cc](343.03044877,847.49771214){\LARGE \entryfont \textcolor{primary-indicator-color}{\ThirdLevelSpellSlotsTotalValue}}
 
+% EXPENDED SLOTS
+\rput[cc](453.03044877,847.49771214){\LARGE \entryfont \textcolor{primary-indicator-color}{\ThirdLevelSpellSlotsExpendedValue}}
+
 % KNOWN SPELLS
 \rput[l](315.17785929,812.43171302){\footnotesize \entryfont \textcolor{text-color}{\ThirdLevelSpellSlotAValue}}
 \rput[l](315.17785929,793.76504682){\footnotesize \entryfont \textcolor{text-color}{\ThirdLevelSpellSlotBValue}}
@@ -80,6 +89,9 @@
 % LEVEL 4
 % TOTAL SLOTS
 \rput[cc](343.03044877,546.71745300){\LARGE \entryfont \textcolor{primary-indicator-color}{\FourthLevelSpellSlotsTotalValue}}
+
+% EXPENDED SLOTS
+\rput[cc](453.03044877,546.71745300){\LARGE \entryfont \textcolor{primary-indicator-color}{\FourthLevelSpellSlotsExpendedValue}}
 
 % KNOWN SPELLS
 \rput[l](315.17785929,511.651053875){\footnotesize \entryfont \textcolor{text-color}{\FourthLevelSpellSlotAValue}}
@@ -100,6 +112,9 @@
 % TOTAL SLOTS
 \rput[cc](343.03044877,244.63252722){\LARGE \entryfont \textcolor{primary-indicator-color}{\FifthLevelSpellSlotsTotalValue}}
 
+% EXPENDED SLOTS
+\rput[cc](453.03044877,244.63252722){\LARGE \entryfont \textcolor{primary-indicator-color}{\FifthLevelSpellSlotsExpendedValue}}
+
 % KNOWN SPELLS
 \rput[l](315.17785929,209.566128095){\footnotesize \entryfont \textcolor{text-color}{\FifthLevelSpellSlotAValue}}
 \rput[l](315.17785929,190.899461895){\footnotesize \entryfont \textcolor{text-color}{\FifthLevelSpellSlotBValue}}
@@ -114,6 +129,9 @@
 % LEVEL 6
 % TOTAL SLOTS
 \rput[cc](592.53044253,847.49771214){\LARGE \entryfont \textcolor{primary-indicator-color}{\SixthLevelSpellSlotsTotalValue}}
+
+% EXPENDED SLOTS
+\rput[cc](702.53044253,847.49771214){\LARGE \entryfont \textcolor{primary-indicator-color}{\SixthLevelSpellSlotsExpendedValue}}
 
 % KNOWN SPELLS
 \rput[l](564.67785305,812.43171302){\footnotesize \entryfont \textcolor{text-color}{\SixthLevelSpellSlotAValue}}
@@ -130,6 +148,9 @@
 % TOTAL SLOTS
 \rput[cc](592.53044253,621.16145114){\LARGE \entryfont \textcolor{primary-indicator-color}{\SeventhLevelSpellSlotsTotalValue}}
 
+% EXPENDED SLOTS
+\rput[cc](702.53044253,621.16145114){\LARGE \entryfont \textcolor{primary-indicator-color}{\SeventhLevelSpellSlotsExpendedValue}}
+
 % KNOWN SPELLS
 \rput[l](564.67785305,586.09505201){\footnotesize \entryfont \textcolor{text-color}{\SeventhLevelSpellSlotAValue}}
 \rput[l](564.67785305,567.42838581){\footnotesize \entryfont \textcolor{text-color}{\SeventhLevelSpellSlotBValue}}
@@ -145,6 +166,9 @@
 % TOTAL SLOTS
 \rput[cc](592.53044253,394.75559013){\LARGE \entryfont \textcolor{primary-indicator-color}{\EighthLevelSpellSlotsTotalValue}}
 
+% EXPENDED SLOTS
+\rput[cc](702.53044253,394.75559013){\LARGE \entryfont \textcolor{primary-indicator-color}{\EighthLevelSpellSlotsExpendedValue}}
+
 % KNOWN SPELLS
 \rput[l](564.67785305,359.68919101){\footnotesize \entryfont \textcolor{text-color}{\EighthLevelSpellSlotAValue}}
 \rput[l](564.67785305,341.02252481){\footnotesize \entryfont \textcolor{text-color}{\EighthLevelSpellSlotBValue}}
@@ -157,6 +181,9 @@
 % LEVEL 9
 % TOTAL SLOTS
 \rput[cc](592.53044253,207.12412815){\LARGE \entryfont \textcolor{primary-indicator-color}{\NinthLevelSpellSlotsTotalValue}}
+
+% EXPENDED SLOTS
+\rput[cc](702.53044253,207.12412815){\LARGE \entryfont \textcolor{primary-indicator-color}{\NinthLevelSpellSlotsExpendedValue}}
 
 % KNOWN SPELLS
 \rput[l](564.67785305,172.05772903){\footnotesize \entryfont \textcolor{text-color}{\NinthLevelSpellSlotAValue}}


### PR DESCRIPTION
Adds the `\<SlotLevel>LevelSpellSlotsExpended{<value>}` command to specify the expended spell slots in LaTex. It works with both the spell sheet and the half spell sheet.
I haven't added it to the tests but I could do that if it is desired.
_Fixes #88_