### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_latex_template.yml
+++ b/.github/workflows/test_latex_template.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "0 13 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     name: Check linting


### PR DESCRIPTION
Potential fix for [https://github.com/matsavage/DND-5e-LaTeX-Character-Sheet-Template/security/code-scanning/4](https://github.com/matsavage/DND-5e-LaTeX-Character-Sheet-Template/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily interacts with the repository contents (e.g., checking out code) and uses secrets. Therefore, we will set `contents: read` as the minimal required permission. If additional permissions are needed for specific jobs, they can be defined within those jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
