### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_overleaf_zip.yml
+++ b/.github/workflows/build_overleaf_zip.yml
@@ -1,5 +1,9 @@
 name: "Build Overleaf Project"
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     tags:

--- a/.github/workflows/build_overleaf_zip.yml
+++ b/.github/workflows/build_overleaf_zip.yml
@@ -48,7 +48,7 @@ jobs:
        id: create_release
        uses: softprops/action-gh-release@v2
        env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        with:
          tag_name: ${{ github.ref_name }}
          files: 'repo/dndtemplate-overleaf-${{ github.ref_name }}.zip'


### PR DESCRIPTION
Potential fix for [https://github.com/matsavage/DND-5e-LaTeX-Character-Sheet-Template/security/code-scanning/1](https://github.com/matsavage/DND-5e-LaTeX-Character-Sheet-Template/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow:
- The `contents: read` permission is needed to check out repositories and access files.
- The `packages: write` permission is required for the `softprops/action-gh-release` step to create a release.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build-archive` job. Adding it at the root level is more concise and ensures consistency across jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
